### PR TITLE
Talos cluster multi node test

### DIFF
--- a/.taskfiles/test/taskfile.yaml
+++ b/.taskfiles/test/taskfile.yaml
@@ -19,3 +19,8 @@ tasks:
     desc: Tests creating a single node talos cluster.
     cmds:
       - (cd tests && go test -v -timeout 10m -run TestTalosClusterSingleNode)
+
+  talos-cluster-ha-cp:
+    desc: Tests creating a high availability control plane talos cluster.
+    cmds:
+      - (cd tests && go test -v -timeout 10m -run TestTalosClusterHACP)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# homelab-terraform-modules
+# Homelab-Terraform-Modules
+
+This repository contains a highly opinionated collection of terraform modules for managing my homelab infrastructure.  They are developed for, and against, my specific configuration of hardware.  As they mature I will attempt to make them more generic and generally useful.
+
+## Usage
+
+Operation of this repository assumes MacOS driven by [`brew`](https://brew.sh/) and [`task`](https://taskfile.dev/).
+
+### Installing Dependencies
+
+```sh
+brew bundle
+```
+
+### Operating
+
+```sh
+task
+```
+
+## License
+
+This project is licensed under the Unlicense. See the [LICENSE](LICENSE) file for details.

--- a/tests/talos_cluster_ha_cp_test.go
+++ b/tests/talos_cluster_ha_cp_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
-func TestTalosClusterSingleNode(t *testing.T) {
-	terraformOptions := createTalosClusterSingleNodeOptions()
+func TestTalosClusterHACP(t *testing.T) {
+	terraformOptions := createTalosClusterHACPOptions()
 	defer func() {
 		resetClusterToMaintenanceMode(t, terraformOptions)
 		destroyTerraformState(t, terraformOptions)
@@ -53,8 +53,9 @@ func TestTalosClusterSingleNode(t *testing.T) {
 	})
 }
 
-func createTalosClusterSingleNodeOptions() *terraform.Options {
-	clusterName := "talos-cluster-single-node-" + random.UniqueId()
+func createTalosClusterHACPOptions() *terraform.Options {
+	clusterName := "talos-cluster-ha-cp-" + random.UniqueId()
+
 	endpoint := "https://192.168.10.246:6443"
 	kubernetes_version := "1.30.1"
 	talos_version := "v1.8.4"
@@ -67,9 +68,61 @@ func createTalosClusterSingleNodeOptions() *terraform.Options {
 	host_dns_enabled := true
 	host_dns_resolveMemberNames := true
 	host_dns_forwardKubeDNSToHost := true
-	// Sourced from: https://github.com/ionfury/homelab-infrastructure/blob/7847cc352ab553b5bb980c828264bbeba52c5e3a/terraform/inventory.hcl#L15
-	// TODO: Reference this directly.
 	hosts := map[string]interface{}{
+		"node44": map[string]interface{}{
+			"cluster": map[string]interface{}{
+				"member": clusterName,
+				"role":   "controlplane",
+			},
+			"disk": map[string]interface{}{
+				"install": "/dev/sda",
+			},
+			"interfaces": []map[string]interface{}{
+				{
+					"hardwareAddr":     "ac:1f:6b:2d:ba:1e",
+					"addresses":        []string{"192.168.10.218"},
+					"dhcp_routeMetric": 50,
+					"vlans": []map[string]interface{}{
+						{
+							"vlanId":           20,
+							"addresses":        []string{"192.168.20.20"},
+							"dhcp_routeMetric": 100,
+						},
+					},
+				},
+			},
+			"ipmi": map[string]interface{}{
+				"ip":  "192.168.10.176",
+				"mac": "ac:1f:6b:68:2b:aa",
+			},
+		},
+		"node45": map[string]interface{}{
+			"cluster": map[string]interface{}{
+				"member": clusterName,
+				"role":   "controlplane",
+			},
+			"disk": map[string]interface{}{
+				"install": "/dev/sda",
+			},
+			"interfaces": []map[string]interface{}{
+				{
+					"hardwareAddr":     "ac:1f:6b:2d:bf:ce",
+					"addresses":        []string{"192.168.10.222"},
+					"dhcp_routeMetric": 50,
+					"vlans": []map[string]interface{}{
+						{
+							"vlanId":           20,
+							"addresses":        []string{"192.168.20.21"},
+							"dhcp_routeMetric": 100,
+						},
+					},
+				},
+			},
+			"ipmi": map[string]interface{}{
+				"ip":  "192.168.10.141",
+				"mac": "ac:1f:6b:68:2a:4b",
+			},
+		},
 		"node46": map[string]interface{}{
 			"cluster": map[string]interface{}{
 				"member": clusterName,

--- a/tests/talos_cluster_helpers.go
+++ b/tests/talos_cluster_helpers.go
@@ -1,0 +1,318 @@
+package test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+type VLAN struct {
+	VlanID          int      `mapstructure:"vlanId"`
+	Addresses       []string `mapstructure:"addresses"`
+	DHCPRouteMetric int      `mapstructure:"dhcp_routeMetric"`
+}
+
+type Interface struct {
+	HardwareAddr    string   `mapstructure:"hardwareAddr"`
+	Addresses       []string `mapstructure:"addresses"`
+	DHCPRouteMetric int      `mapstructure:"dhcp_routeMetric"`
+	VLANs           []VLAN   `mapstructure:"vlans"`
+}
+
+type IPMI struct {
+	IP  string `mapstructure:"ip"`
+	MAC string `mapstructure:"mac"`
+}
+
+type Disk struct {
+	Install string `mapstructure:"install"`
+}
+
+type Cluster struct {
+	Member string `mapstructure:"member"`
+	Role   string `mapstructure:"role"`
+}
+
+type Host struct {
+	Cluster    Cluster     `mapstructure:"cluster"`
+	Disk       Disk        `mapstructure:"disk"`
+	Interfaces []Interface `mapstructure:"interfaces"`
+	IPMI       IPMI        `mapstructure:"ipmi"`
+}
+
+type Hosts map[string]Host
+
+func destroyTerraformState(t *testing.T, terraformOptions *terraform.Options) {
+	destroyCmd := shell.Command{
+		Command:    "terraform",
+		Args:       []string{"destroy", "-auto-approve", "-refresh=false"},
+		Env:        terraformOptions.EnvVars,
+		WorkingDir: terraformOptions.TerraformDir,
+	}
+
+	err := shell.RunCommandE(t, destroyCmd)
+	assert.NoError(t, err, "Failed to destroy resources")
+}
+
+func validateTalosHostDnsConfig(t *testing.T, terraformOptions *terraform.Options) {
+	talosConfigFilePath := terraform.Output(t, terraformOptions, "talos_config_file_path")
+
+	hostDnsEnabled, ok := terraformOptions.Vars["host_dns_enabled"].(bool)
+	if !ok {
+		t.Fatalf("host_dns_enabled variable is not set or is not a boolean")
+	}
+
+	if hostDnsEnabled {
+		hosts, ok := terraformOptions.Vars["hosts"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("hosts variable is not set or is not a map")
+		}
+
+		resolveMemberNames, ok := terraformOptions.Vars["host_dns_resolveMemberNames"].(bool)
+		if !ok {
+			t.Fatalf("host_dns_resolveMemberNames variable is not set or is not a boolean")
+		}
+
+		for hostName := range hosts {
+			talosctlCmd := shell.Command{
+				Command: "talosctl",
+				Args:    []string{"--talosconfig", talosConfigFilePath, "-n", hostName, "get", "hostdnsconfig", "-o", "json"},
+			}
+
+			json, err := shell.RunCommandAndGetOutputE(t, talosctlCmd)
+			if err != nil {
+				t.Fatalf("Failed to run talosctl command: %v", err)
+			}
+
+			assert.Equal(t, hostDnsEnabled, gjson.Get(json, "spec.enabled").Bool(), "Host DNS for host %s is not enabled", hostName)
+			assert.Equal(t, resolveMemberNames, gjson.Get(json, "spec.resolveMemberNames").Bool(), "ResolveMemberNames for host %s does not match", hostName)
+		}
+	}
+}
+
+func validateTalosHostnameConfig(t *testing.T, terraformOptions *terraform.Options) {
+	talosConfigFilePath := terraform.Output(t, terraformOptions, "talos_config_file_path")
+
+	hosts, ok := terraformOptions.Vars["hosts"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("hosts variable is not set or is not a map")
+	}
+
+	for hostName := range hosts {
+		talosctlCmd := shell.Command{
+			Command: "talosctl",
+			Args:    []string{"--talosconfig", talosConfigFilePath, "-n", hostName, "get", "hostname", "-o", "json"},
+		}
+
+		json, err := shell.RunCommandAndGetOutputE(t, talosctlCmd)
+		if err != nil {
+			t.Fatalf("Failed to run talosctl command: %v", err)
+		}
+
+		assert.Equal(t, hostName, gjson.Get(json, "spec.hostname").String(), "Hostname for host %s does not match", hostName)
+	}
+}
+
+func validateTalosInstallDiskConfig(t *testing.T, terraformOptions *terraform.Options) {
+	talosConfigFilePath := terraform.Output(t, terraformOptions, "talos_config_file_path")
+	hosts, ok := terraformOptions.Vars["hosts"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("hosts variable is not set or is not a map")
+	}
+
+	var decodedHosts Hosts
+	err := mapstructure.Decode(hosts, &decodedHosts)
+	if err != nil {
+		t.Fatalf("Failed to decode hosts: %v", err)
+	}
+
+	for hostName, hostConfig := range decodedHosts {
+		talosctlCmd := shell.Command{
+			Command: "talosctl",
+			Args:    []string{"--talosconfig", talosConfigFilePath, "-n", hostName, "get", "systemdisk", "-o", "json"},
+		}
+
+		json, err := shell.RunCommandAndGetOutputE(t, talosctlCmd)
+		if err != nil {
+			t.Fatalf("Failed to run talosctl command: %v", err)
+		}
+
+		assert.Equal(t, hostConfig.Disk.Install, gjson.Get(json, "spec.devPath").String(), "Install disk for host %s does not match", hostName)
+	}
+}
+
+func validateTalosInterfaceHardwareAddrConfig(t *testing.T, terraformOptions *terraform.Options) {
+	talosConfigFilePath := terraform.Output(t, terraformOptions, "talos_config_file_path")
+	hosts, ok := terraformOptions.Vars["hosts"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("hosts variable is not set or is not a map")
+	}
+
+	var decodedHosts Hosts
+	err := mapstructure.Decode(hosts, &decodedHosts)
+	if err != nil {
+		t.Fatalf("Failed to decode hosts: %v", err)
+	}
+
+	for hostName, hostConfig := range decodedHosts {
+		for _, iface := range hostConfig.Interfaces {
+			talosctlCmd := shell.Command{
+				Command: "talosctl",
+				Args:    []string{"--talosconfig", talosConfigFilePath, "-n", hostName, "get", "link", "-o", "json"},
+			}
+
+			json, err := shell.RunCommandAndGetOutputE(t, talosctlCmd)
+			if err != nil {
+				t.Fatalf("Failed to run talosctl command: %v", err)
+			}
+
+			assert.Equal(t, iface.HardwareAddr, gjson.Get(json, "spec.hardwareAddr").String(), "Hardware address for host %s does not match", hostName)
+		}
+	}
+}
+
+func validateTalosNameserversConfig(t *testing.T, terraformOptions *terraform.Options) {
+	talosConfigFilePath := terraform.Output(t, terraformOptions, "talos_config_file_path")
+	hosts, ok := terraformOptions.Vars["hosts"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("hosts variable is not set or is not a map")
+	}
+
+	expectedNameservers, ok := terraformOptions.Vars["nameservers"].([]string)
+	if !ok {
+		t.Fatalf("nameservers variable is not set or is not a list of strings")
+	}
+
+	for hostName := range hosts {
+		talosctlCmd := shell.Command{
+			Command: "talosctl",
+			Args:    []string{"--talosconfig", talosConfigFilePath, "-n", hostName, "get", "resolvers", "-o", "json"},
+		}
+
+		json, err := shell.RunCommandAndGetOutputE(t, talosctlCmd)
+		if err != nil {
+			t.Fatalf("Failed to run talosctl command: %v", err)
+		}
+
+		nameservers := gjson.Get(json, "spec.dnsServers").Array()
+		var actualNameservers []string
+		for _, nameserver := range nameservers {
+			actualNameservers = append(actualNameservers, nameserver.String())
+		}
+
+		assert.Equal(t, expectedNameservers, actualNameservers, "Configured nameservers for host %s do not match", hostName)
+	}
+}
+
+func validateTalosNTPServersConfig(t *testing.T, terraformOptions *terraform.Options) {
+	talosConfigFilePath := terraform.Output(t, terraformOptions, "talos_config_file_path")
+	hosts, ok := terraformOptions.Vars["hosts"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("hosts variable is not set or is not a map")
+	}
+
+	expectedNTPServers, ok := terraformOptions.Vars["ntp_servers"].([]string)
+	if !ok {
+		t.Fatalf("ntp_servers variable is not set or is not a list of strings")
+	}
+
+	for hostName := range hosts {
+		talosctlCmd := shell.Command{
+			Command: "talosctl",
+			Args:    []string{"--talosconfig", talosConfigFilePath, "-n", hostName, "get", "timeservers", "-o", "json"},
+		}
+
+		json, err := shell.RunCommandAndGetOutputE(t, talosctlCmd)
+		if err != nil {
+			t.Fatalf("Failed to run talosctl command: %v", err)
+		}
+
+		timeservers := gjson.Get(json, "spec.timeServers").Array()
+		var actualNTPServers []string
+		for _, timeserver := range timeservers {
+			actualNTPServers = append(actualNTPServers, timeserver.String())
+		}
+
+		assert.Equal(t, expectedNTPServers, actualNTPServers, "Configured NTP servers for host %s do not match", hostName)
+	}
+}
+
+func validateTalosControlPlaneSchedulingConfig(t *testing.T, terraformOptions *terraform.Options) {
+	talosConfigFilePath := terraform.Output(t, terraformOptions, "talos_config_file_path")
+	hosts, ok := terraformOptions.Vars["hosts"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("hosts variable is not set or is not a map")
+	}
+
+	allowSchedulingOnControlplane, ok := terraformOptions.Vars["allow_scheduling_on_controlplane"].(bool)
+	if !ok {
+		t.Fatalf("allow_scheduling_on_controlplane variable is not set or is not a boolean")
+	}
+
+	for hostName := range hosts {
+		talosctlCmd := shell.Command{
+			Command: "talosctl",
+			Args:    []string{"--talosconfig", talosConfigFilePath, "-n", hostName, "get", "schedulerconfig", "-o", "json"},
+		}
+
+		json, err := shell.RunCommandAndGetOutputE(t, talosctlCmd)
+		if err != nil {
+			t.Fatalf("Failed to run talosctl command: %v", err)
+		}
+
+		assert.Equal(t, allowSchedulingOnControlplane, gjson.Get(json, "spec.enabled").Bool(), "AllowScheduling for host %s does not match", hostName)
+	}
+}
+
+func validateKubernetesVersionConfig(t *testing.T, terraformOptions *terraform.Options) {
+	kubeConfigPath := terraform.Output(t, terraformOptions, "kubernetes_config_file_path")
+
+	kubectlCmd := shell.Command{
+		Command: "kubectl",
+		Args:    []string{"--kubeconfig", kubeConfigPath, "version", "-o", "json"},
+	}
+
+	output, err := shell.RunCommandAndGetOutputE(t, kubectlCmd)
+	if err != nil {
+		t.Fatalf("Failed to run kubectl command: %v", err)
+	}
+
+	expectedVersion := "v" + terraformOptions.Vars["kubernetes_version"].(string)
+	assert.Equal(t, expectedVersion, gjson.Get(output, "serverVersion.gitVersion").String(), "Kubernetes version does not match the provided version")
+}
+
+func resetClusterToMaintenanceMode(t *testing.T, terraformOptions *terraform.Options) {
+	talosConfigPath := terraform.Output(t, terraformOptions, "talos_config_file_path")
+
+	hosts, ok := terraformOptions.Vars["hosts"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("hosts variable is not set or is not a map")
+	}
+
+	var wg sync.WaitGroup
+	for hostName := range hosts {
+		wg.Add(1)
+		go func(hostName string) {
+			defer wg.Done()
+			talosctlCmd := shell.Command{
+				Command: "talosctl",
+				Args:    []string{"--talosconfig", talosConfigPath, "--nodes", hostName, "reset", "--reboot", "--graceful=false", "--wait=false"},
+			}
+
+			err := shell.RunCommandE(t, talosctlCmd)
+			assert.NoError(t, err, "Failed to reset the cluster node %s into maintenance mode", hostName)
+		}(hostName)
+	}
+	wg.Wait()
+}
+
+func validateTalosNodeIpConfig(t *testing.T, terraformOptions *terraform.Options) {}
+
+func validateTalosLinkConfig(t *testing.T, terraformOptions *terraform.Options) {}
+
+func validateTalosRouteConfig(t *testing.T, terraformOptions *terraform.Options) {}


### PR DESCRIPTION
This pull request introduces several significant changes to the repository, including the addition of a new test for high availability control plane Talos clusters, updates to the README file, and the extraction of common test helper functions. 

### New Test for High Availability Control Plane Talos Clusters:
* Added a new task `talos-cluster-ha-cp` to `.taskfiles/test/taskfile.yaml` to test creating a high availability control plane Talos cluster.
* Introduced a new test file `tests/talos_cluster_ha_cp_test.go` to implement the high availability control plane Talos cluster test.

### Documentation Updates:
* Updated the `README.md` file to include a detailed description of the repository, usage instructions, and license information.

### Codebase Simplification and Refactoring:
* Extracted common test helper functions into a new file `tests/talos_cluster_helpers.go` to avoid code duplication and improve maintainability.
* Removed redundant code and simplified the test setup in `tests/talos_cluster_single_node_test.go` by leveraging the new helper functions. [[1]](diffhunk://#diff-50193c17723efa9702ec32aa4a9a2c6b8bf8a7ebb408b7c1f2f4794233673541L6-L49) [[2]](diffhunk://#diff-50193c17723efa9702ec32aa4a9a2c6b8bf8a7ebb408b7c1f2f4794233673541L96-L120)