### PR TITLE
Add Unifi DNS module

### DIFF
--- a/modules/unifi-dns/README.md
+++ b/modules/unifi-dns/README.md
@@ -1,0 +1,40 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~>5.80.0 |
+| <a name="requirement_unifi"></a> [unifi](#requirement\_unifi) | 0.41.2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.80.0 |
+| <a name="provider_unifi"></a> [unifi](#provider\_unifi) | 0.41.2 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [unifi_dns_record.record](https://registry.terraform.io/providers/ubiquiti-community/unifi/0.41.2/docs/resources/dns_record) | resource |
+| [aws_ssm_parameter.unifi_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.unifi_username](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws"></a> [aws](#input\_aws) | AWS account information. | <pre>object({<br/>    region  = string<br/>    profile = string<br/>  })</pre> | <pre>{<br/>  "profile": "terragrunt",<br/>  "region": "us-east-2"<br/>}</pre> | no |
+| <a name="input_unifi"></a> [unifi](#input\_unifi) | Unifi controller information | <pre>object({<br/>    address        = string<br/>    username_store = string<br/>    password_store = string<br/>    site           = string<br/>  })</pre> | <pre>{<br/>  "address": "https://192.168.1.1",<br/>  "password_store": "/homelab/unifi/terraform/password",<br/>  "site": "default",<br/>  "username_store": "/homelab/unifi/terraform/username"<br/>}</pre> | no |
+| <a name="input_unifi_dns_records"></a> [unifi\_dns\_records](#input\_unifi\_dns\_records) | List of DNS records to add to the Unifi controller. | <pre>map(object({<br/>    name        = optional(string, null)<br/>    value       = string<br/>    enabled     = optional(bool, true)<br/>    port        = optional(number, 0)<br/>    priority    = optional(number, 0)<br/>    record_type = optional(string, "A")<br/>    ttl         = optional(number, 0)<br/>  }))</pre> | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/unifi-dns/main.tf
+++ b/modules/unifi-dns/main.tf
@@ -1,0 +1,11 @@
+resource "unifi_dns_record" "record" {
+  for_each = var.unifi_dns_records
+
+  name        = coalesce(each.value.name, each.key)
+  value       = each.value.value
+  enabled     = each.value.enabled
+  port        = each.value.port
+  priority    = each.value.priority
+  record_type = each.value.record_type
+  ttl         = each.value.ttl
+}

--- a/modules/unifi-dns/provider.tf
+++ b/modules/unifi-dns/provider.tf
@@ -1,0 +1,19 @@
+provider "aws" {
+  region  = var.aws.region
+  profile = var.aws.profile
+}
+
+data "aws_ssm_parameter" "unifi_username" {
+  name = var.unifi.username_store
+}
+
+data "aws_ssm_parameter" "unifi_password" {
+  name = var.unifi.password_store
+}
+provider "unifi" {
+  api_url        = var.unifi.address
+  username       = data.aws_ssm_parameter.unifi_username.value
+  password       = data.aws_ssm_parameter.unifi_password.value
+  allow_insecure = true
+  site           = var.unifi.site
+}

--- a/modules/unifi-dns/variables.tf
+++ b/modules/unifi-dns/variables.tf
@@ -1,0 +1,44 @@
+variable "aws" {
+  description = "AWS account information."
+  type = object({
+    region  = string
+    profile = string
+  })
+  default = {
+    region  = "us-east-2"
+    profile = "terragrunt"
+  }
+}
+
+variable "unifi" {
+  description = "Unifi controller information"
+  type = object({
+    address        = string
+    username_store = string
+    password_store = string
+    site           = string
+  })
+  default = {
+    address        = "https://192.168.1.1"
+    username_store = "/homelab/unifi/terraform/username"
+    password_store = "/homelab/unifi/terraform/password"
+    site           = "default"
+  }
+}
+
+variable "unifi_dns_records" {
+  description = "List of DNS records to add to the Unifi controller."
+  type = map(object({
+    name        = optional(string, null)
+    value       = string
+    enabled     = optional(bool, true)
+    port        = optional(number, 0)
+    priority    = optional(number, 0)
+    record_type = optional(string, "A")
+    ttl         = optional(number, 0)
+  }))
+  validation {
+    condition     = alltrue([for record in var.unifi_dns_records : can(regex("^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}$", record.value))])
+    error_message = "Each DNS record value must be a valid IP address."
+  }
+}

--- a/modules/unifi-dns/versions.tf
+++ b/modules/unifi-dns/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.6.6"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~>5.80.0"
+    }
+    unifi = {
+      source  = "ubiquiti-community/unifi"
+      version = "0.41.2"
+    }
+  }
+}

--- a/tests/talos_cluster_ha_cp_test.go
+++ b/tests/talos_cluster_ha_cp_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestTalosClusterHACP(t *testing.T) {
 	terraformOptions := createTalosClusterHACPOptions()
-	defer func() {
+	/*defer func() {
 		resetClusterToMaintenanceMode(t, terraformOptions)
 		destroyTerraformState(t, terraformOptions)
-	}()
+	}()*/
 	terraform.InitAndApply(t, terraformOptions)
 
 	t.Run("group", func(t *testing.T) {
@@ -56,12 +56,12 @@ func TestTalosClusterHACP(t *testing.T) {
 func createTalosClusterHACPOptions() *terraform.Options {
 	clusterName := "talos-cluster-ha-cp-" + random.UniqueId()
 
-	endpoint := "https://192.168.10.246:6443"
+	endpoint := "https://test.citadel.tomnowak.work:6443"
 	kubernetes_version := "1.30.1"
 	talos_version := "v1.8.4"
 	talos_config_path := "~/.talos"
 	kubernetes_config_path := "~/.kube"
-	nameservers := []string{"8.8.8.8", "1.1.1.1"}
+	nameservers := []string{"192.168.1.1"}
 	ntp_servers := []string{"0.pool.ntp.org", "1.pool.ntp.org"}
 	cluster_vip := "192.168.10.5"
 	allow_scheduling_on_controlplane := true

--- a/tests/talos_cluster_helpers.go
+++ b/tests/talos_cluster_helpers.go
@@ -312,7 +312,9 @@ func resetClusterToMaintenanceMode(t *testing.T, terraformOptions *terraform.Opt
 	wg.Wait()
 }
 
-func validateTalosNodeIpConfig(t *testing.T, terraformOptions *terraform.Options) {}
+func validateTalosNodeIpConfig(t *testing.T, terraformOptions *terraform.Options) {
+
+}
 
 func validateTalosLinkConfig(t *testing.T, terraformOptions *terraform.Options) {}
 

--- a/tests/unifi_dns_test.go
+++ b/tests/unifi_dns_test.go
@@ -1,0 +1,59 @@
+package test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnifiDNS(t *testing.T) {
+	terraformOptions := createUnifiDNSOptions()
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+
+	t.Run("group", func(t *testing.T) {
+		t.Run("validateUnifiDNS", func(t *testing.T) {
+			t.Parallel()
+			validateUnifiDNS(t, terraformOptions)
+		})
+	})
+}
+
+func createUnifiDNSOptions() *terraform.Options {
+	return &terraform.Options{
+		TerraformDir: "../modules/unifi-dns",
+		Vars: map[string]interface{}{
+			"unifi_dns_records": map[string]interface{}{
+				"record": map[string]interface{}{
+					"name":  random.UniqueId() + ".com",
+					"value": "192.168.111.111",
+				},
+			},
+		},
+	}
+}
+
+func validateUnifiDNS(t *testing.T, terraformOptions *terraform.Options) {
+	records := make(map[string]string)
+	for _, value := range terraformOptions.Vars["unifi_dns_records"].(map[string]interface{}) {
+		record := value.(map[string]interface{})
+		records[record["name"].(string)] = record["value"].(string)
+	}
+	time.Sleep(10 * time.Second)
+	for expectedValue, ip := range records {
+		cmd := shell.Command{
+			Command: "nslookup",
+			Args:    []string{expectedValue},
+		}
+		output, err := shell.RunCommandAndGetOutputE(t, cmd)
+		if err != nil {
+			t.Fatalf("Failed to run nslookup: %v", err)
+		}
+
+		assert.Contains(t, string(output), ip, "Expected IP %s for %s, but got %s", ip, expectedValue, string(output))
+	}
+}


### PR DESCRIPTION
This pull request introduces several changes to the `unifi-dns` module and its associated tests. The most significant changes include the addition of documentation, new resource and provider configurations, and a new test file for Unifi DNS functionality.

### Documentation:
* Added comprehensive documentation to `modules/unifi-dns/README.md` outlining requirements, providers, modules, resources, inputs, and outputs.

### Resource and Provider Configuration:
* Defined a new `unifi_dns_record` resource in `modules/unifi-dns/main.tf` to manage DNS records.
* Configured AWS and Unifi providers in `modules/unifi-dns/provider.tf`, including fetching Unifi credentials from AWS SSM parameters.
* Added variable definitions for AWS account information and Unifi controller details in `modules/unifi-dns/variables.tf`.
* Specified required Terraform and provider versions in `modules/unifi-dns/versions.tf`.

### Testing:
* Introduced a new test file `tests/unifi_dns_test.go` to validate the Unifi DNS records setup using Terratest.

These changes enhance the functionality and test coverage of the `unifi-dns` module, making it more robust and easier to manage.