### PR TITLE
Add Talos Image Schematic to Module

### DIFF
--- a/.taskfiles/terraform/taskfile.yaml
+++ b/.taskfiles/terraform/taskfile.yaml
@@ -18,36 +18,43 @@ tasks:
       - task: docs
 
   lint:
+    internal: true
     desc: Lints the terraform configuration files.
     cmds:
       - tflint --recursive --fix
 
   lint-check:
+    internal: true
     desc: Checks if the terraform configuration files are linted.
     cmds:
       - tflint --recursive
 
   fmt:
+    internal: true
     desc: Formats the terraform configuration files.
     cmds:
       - terraform fmt -recursive
 
   fmt-check:
+    internal: true
     desc: Checks if the terraform configuration files are formatted.
     cmds:
       - terraform fmt -recursive -check
   
   docs-check:
+    internal: true
     desc: Checks if the terraform configuration files are documented.
     cmds:
       - find {{ .MODULES_DIR }} -type d -maxdepth 1 -mindepth 1 -exec sh -c 'cd "{}" && terraform-docs markdown --output-file README.md --output-check .' \;
 
   docs:
+    internal: true
     desc: Generates docs for all terraform modules.
     cmds: 
       - find {{ .MODULES_DIR }} -type d -maxdepth 1 -mindepth 1 -exec sh -c 'cd "{}" && terraform-docs markdown --output-file README.md .' \;
 
   validate:
+    internal: true
     desc: Validates the terraform configuration files.
     cmds:
       - find {{ .MODULES_DIR }} -type d -maxdepth 1 -mindepth 1  -exec sh -c 'cd "{}" && terraform init --backend=false && terraform validate' \;

--- a/modules/talos-cluster/README.md
+++ b/modules/talos-cluster/README.md
@@ -6,7 +6,7 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.17.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | 2.1.0 |
-| <a name="requirement_talos"></a> [talos](#requirement\_talos) | 0.7.0-alpha.0 |
+| <a name="requirement_talos"></a> [talos](#requirement\_talos) | 0.7.0 |
 
 ## Providers
 
@@ -14,7 +14,7 @@
 |------|---------|
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.17.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | 2.1.0 |
-| <a name="provider_talos"></a> [talos](#provider\_talos) | 0.7.0-alpha.0 |
+| <a name="provider_talos"></a> [talos](#provider\_talos) | 0.7.0 |
 
 ## Modules
 
@@ -26,14 +26,17 @@ No modules.
 |------|------|
 | [local_file.kubeconfig](https://registry.terraform.io/providers/hashicorp/local/2.1.0/docs/resources/file) | resource |
 | [local_file.talosconfig](https://registry.terraform.io/providers/hashicorp/local/2.1.0/docs/resources/file) | resource |
-| [talos_cluster_kubeconfig.this](https://registry.terraform.io/providers/siderolabs/talos/0.7.0-alpha.0/docs/resources/cluster_kubeconfig) | resource |
-| [talos_machine_bootstrap.this](https://registry.terraform.io/providers/siderolabs/talos/0.7.0-alpha.0/docs/resources/machine_bootstrap) | resource |
-| [talos_machine_configuration_apply.hosts](https://registry.terraform.io/providers/siderolabs/talos/0.7.0-alpha.0/docs/resources/machine_configuration_apply) | resource |
-| [talos_machine_secrets.this](https://registry.terraform.io/providers/siderolabs/talos/0.7.0-alpha.0/docs/resources/machine_secrets) | resource |
+| [talos_cluster_kubeconfig.this](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/resources/cluster_kubeconfig) | resource |
+| [talos_image_factory_schematic.host_schematic](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/resources/image_factory_schematic) | resource |
+| [talos_machine_bootstrap.this](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/resources/machine_bootstrap) | resource |
+| [talos_machine_configuration_apply.hosts](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/resources/machine_configuration_apply) | resource |
+| [talos_machine_secrets.this](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/resources/machine_secrets) | resource |
 | [helm_template.cilium](https://registry.terraform.io/providers/hashicorp/helm/2.17.0/docs/data-sources/template) | data source |
-| [talos_client_configuration.this](https://registry.terraform.io/providers/siderolabs/talos/0.7.0-alpha.0/docs/data-sources/client_configuration) | data source |
-| [talos_cluster_health.this](https://registry.terraform.io/providers/siderolabs/talos/0.7.0-alpha.0/docs/data-sources/cluster_health) | data source |
-| [talos_machine_configuration.control_plane](https://registry.terraform.io/providers/siderolabs/talos/0.7.0-alpha.0/docs/data-sources/machine_configuration) | data source |
+| [talos_client_configuration.this](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/data-sources/client_configuration) | data source |
+| [talos_cluster_health.this](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/data-sources/cluster_health) | data source |
+| [talos_image_factory_extensions_versions.host_version](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/data-sources/image_factory_extensions_versions) | data source |
+| [talos_image_factory_urls.host_image_url](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/data-sources/image_factory_urls) | data source |
+| [talos_machine_configuration.control_plane](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/data-sources/machine_configuration) | data source |
 
 ## Inputs
 
@@ -41,17 +44,21 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_allow_scheduling_on_controlplane"></a> [allow\_scheduling\_on\_controlplane](#input\_allow\_scheduling\_on\_controlplane) | Whether to allow scheduling on the controlplane. | `bool` | `true` | no |
 | <a name="input_cilium_version"></a> [cilium\_version](#input\_cilium\_version) | The version of Cilium to use. | `string` | `"1.16.5"` | no |
+| <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | An ID to provide for the Talos cluster. | `number` | `1` | no |
 | <a name="input_cluster_vip"></a> [cluster\_vip](#input\_cluster\_vip) | The VIP to use for the Talos cluster. Applied to the first interface of control plane hosts. | `string` | `"192.168.10.5"` | no |
 | <a name="input_endpoint"></a> [endpoint](#input\_endpoint) | The endpoint for the Talos cluster. | `string` | `"https://192.168.10.246:6443"` | no |
 | <a name="input_host_dns_enabled"></a> [host\_dns\_enabled](#input\_host\_dns\_enabled) | Whether to enable host DNS. | `bool` | `true` | no |
 | <a name="input_host_dns_forwardKubeDNSToHost"></a> [host\_dns\_forwardKubeDNSToHost](#input\_host\_dns\_forwardKubeDNSToHost) | Whether to forward kube DNS to the host. | `bool` | `true` | no |
 | <a name="input_host_dns_resolveMemberNames"></a> [host\_dns\_resolveMemberNames](#input\_host\_dns\_resolveMemberNames) | Whether to resolve member names. | `bool` | `true` | no |
-| <a name="input_hosts"></a> [hosts](#input\_hosts) | A map of current hosts from which to build the Talos cluster. | <pre>map(object({<br/>    cluster = object({<br/>      member = string<br/>      role   = string<br/>    })<br/>    install = object({<br/>      diskSelector = list(string) # https://www.talos.dev/v1.9/reference/configuration/v1alpha1/config/#Config.machine.install.diskSelector<br/>    })<br/>    interfaces = list(object({<br/>      hardwareAddr     = string<br/>      addresses        = list(string)<br/>      dhcp_routeMetric = number<br/>      vlans = list(object({<br/>        vlanId           = number<br/>        addresses        = list(string)<br/>        dhcp_routeMetric = number<br/>      }))<br/>    }))<br/>    ipmi = object({<br/>      ip  = string<br/>      mac = string<br/>    })<br/>  }))</pre> | <pre>{<br/>  "node46": {<br/>    "cluster": {<br/>      "member": "cluster",<br/>      "role": "controlplane"<br/>    },<br/>    "install": {<br/>      "diskSelector": [<br/>        "type: 'ssd'"<br/>      ]<br/>    },<br/>    "interfaces": [<br/>      {<br/>        "addresses": [<br/>          "192.168.10.246"<br/>        ],<br/>        "dhcp_routeMetric": 100,<br/>        "hardwareAddr": "ac:1f:6b:2d:c0:22",<br/>        "vlans": [<br/>          {<br/>            "addresses": [<br/>              "192.168.20.10"<br/>            ],<br/>            "dhcp_routeMetric": 100,<br/>            "vlanId": 10<br/>          }<br/>        ]<br/>      }<br/>    ],<br/>    "ipmi": {<br/>      "ip": "192.168.10.231",<br/>      "mac": "ac:1f:6b:68:2b:e1"<br/>    }<br/>  }<br/>}</pre> | no |
+| <a name="input_hosts"></a> [hosts](#input\_hosts) | A map of current hosts from which to build the Talos cluster. | <pre>map(object({<br/>    cluster = object({<br/>      member = string<br/>      role   = string<br/>    })<br/>    install = object({<br/>      diskSelector    = list(string) # https://www.talos.dev/v1.9/reference/configuration/v1alpha1/config/#Config.machine.install.diskSelector<br/>      extraKernelArgs = optional(list(string), [])<br/>      extensions      = optional(list(string), [])<br/>      secureboot      = optional(bool, false)<br/>      wipe            = optional(bool, false)<br/>      architecture    = optional(string, "amd64")<br/>      platform        = optional(string, "metal")<br/><br/>    })<br/>    interfaces = list(object({<br/>      hardwareAddr     = string<br/>      addresses        = list(string)<br/>      dhcp_routeMetric = number<br/>      vlans = list(object({<br/>        vlanId           = number<br/>        addresses        = list(string)<br/>        dhcp_routeMetric = number<br/>      }))<br/>    }))<br/>    ipmi = object({<br/>      ip  = string<br/>      mac = string<br/>    })<br/>  }))</pre> | <pre>{<br/>  "node46": {<br/>    "cluster": {<br/>      "member": "cluster",<br/>      "role": "controlplane"<br/>    },<br/>    "install": {<br/>      "diskSelector": [<br/>        "type: 'ssd'"<br/>      ],<br/>      "extensions": [<br/>        "iscsi-tools",<br/>        "util-linux-tools"<br/>      ],<br/>      "extraKernelArgs": [<br/>        "apparmor=0"<br/>      ],<br/>      "secureboot": false,<br/>      "wipe": false<br/>    },<br/>    "interfaces": [<br/>      {<br/>        "addresses": [<br/>          "192.168.10.246"<br/>        ],<br/>        "dhcp_routeMetric": 100,<br/>        "hardwareAddr": "ac:1f:6b:2d:c0:22",<br/>        "vlans": [<br/>          {<br/>            "addresses": [<br/>              "192.168.20.10"<br/>            ],<br/>            "dhcp_routeMetric": 100,<br/>            "vlanId": 10<br/>          }<br/>        ]<br/>      }<br/>    ],<br/>    "ipmi": {<br/>      "ip": "192.168.10.231",<br/>      "mac": "ac:1f:6b:68:2b:e1"<br/>    }<br/>  }<br/>}</pre> | no |
 | <a name="input_kubernetes_config_path"></a> [kubernetes\_config\_path](#input\_kubernetes\_config\_path) | The path to the Kubernetes configuration file. | `string` | `"~/.kube"` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | The version of kubernetes to deploy. | `string` | `"1.30.1"` | no |
 | <a name="input_name"></a> [name](#input\_name) | A name to provide for the Talos cluster. | `string` | `"cluster"` | no |
 | <a name="input_nameservers"></a> [nameservers](#input\_nameservers) | A list of nameservers to use for the Talos cluster. | `list(string)` | <pre>[<br/>  "1.1.1.1",<br/>  "1.0.0.1"<br/>]</pre> | no |
+| <a name="input_node_subnet"></a> [node\_subnet](#input\_node\_subnet) | The subnet to use for the Talos cluster nodes. | `string` | `"192.168.10.0/24"` | no |
 | <a name="input_ntp_servers"></a> [ntp\_servers](#input\_ntp\_servers) | A list of NTP servers to use for the Talos cluster. | `list(string)` | <pre>[<br/>  "0.pool.ntp.org",<br/>  "1.pool.ntp.org"<br/>]</pre> | no |
+| <a name="input_pod_subnet"></a> [pod\_subnet](#input\_pod\_subnet) | The pod subnet to use for pods on the Talos cluster. | `string` | `"172.16.0.0/16"` | no |
+| <a name="input_service_subnet"></a> [service\_subnet](#input\_service\_subnet) | The pod subnet to use for services on the Talos cluster. | `string` | `"172.17.0.0/16"` | no |
 | <a name="input_talos_config_path"></a> [talos\_config\_path](#input\_talos\_config\_path) | The path to the Talos configuration file. | `string` | `"~/.talos"` | no |
 | <a name="input_talos_version"></a> [talos\_version](#input\_talos\_version) | The version of Talos to use. | `string` | `"v1.8.3"` | no |
 

--- a/modules/talos-cluster/apply.tf
+++ b/modules/talos-cluster/apply.tf
@@ -21,7 +21,10 @@ resource "talos_machine_configuration_apply" "hosts" {
     }),
 
     templatefile("${path.module}/resources/templates/machine_install.yaml.tmpl", {
-      disk_selectors = each.value.install.diskSelector
+      disk_selectors    = each.value.install.diskSelector
+      extra_kernel_args = each.value.install.extraKernelArgs
+      disk_image        = each.value.install.secureboot ? data.talos_image_factory_urls.host_image_url[each.key].urls.installer_secureboot : data.talos_image_factory_urls.host_image_url[each.key].urls.installer
+      wipe              = each.value.install.wipe
     }),
 
     templatefile("${path.module}/resources/templates/machine_network_namerservers.yaml.tmpl", {
@@ -49,7 +52,7 @@ resource "talos_machine_configuration_apply" "hosts" {
     }),
 
     templatefile("${path.module}/resources/templates/machine_kubelet_nodeip_validSubnets.yaml.tmpl", {
-      cluster_subnet = var.cluster_subnet
+      node_subnet = var.node_subnet
     }),
 
     templatefile("${path.module}/resources/templates/cluster_inlineManifests.yaml.tmpl", {

--- a/modules/talos-cluster/cilium.tf
+++ b/modules/talos-cluster/cilium.tf
@@ -8,7 +8,7 @@ data "helm_template" "cilium" {
   values = [
     templatefile("${path.module}/resources/templates/cilium.yaml.tmpl", {
       cluster_name   = var.name
-      cluster_id     = 1
+      cluster_id     = var.cluster_id
       pod_subnet     = var.pod_subnet
       service_subnet = var.service_subnet
     })

--- a/modules/talos-cluster/image.tf
+++ b/modules/talos-cluster/image.tf
@@ -1,0 +1,36 @@
+data "talos_image_factory_extensions_versions" "host_version" {
+  for_each = var.hosts
+
+  talos_version = var.talos_version
+
+  filters = {
+    names = each.value.install.extensions
+  }
+}
+
+resource "talos_image_factory_schematic" "host_schematic" {
+  for_each = var.hosts
+
+  schematic = yamlencode(
+    {
+      customization = {
+        systemExtensions = {
+          officialExtensions = data.talos_image_factory_extensions_versions.host_version[each.key].extensions_info[*].name
+        }
+        extraKernelArgs = each.value.install.extraKernelArgs
+        secureboot = {
+          enabled = each.value.install.secureboot
+        }
+      }
+    }
+  )
+}
+
+data "talos_image_factory_urls" "host_image_url" {
+  for_each = var.hosts
+
+  talos_version = var.talos_version
+  schematic_id  = talos_image_factory_schematic.host_schematic[each.key].id
+  platform      = each.value.install.platform
+  architecture  = each.value.install.architecture
+}

--- a/modules/talos-cluster/resources/templates/cilium.yaml.tmpl
+++ b/modules/talos-cluster/resources/templates/cilium.yaml.tmpl
@@ -12,10 +12,10 @@ cgroup:
     enabled: false
   hostRoot: /sys/fs/cgroup
 cni:
-  exclusive: false #to run multus
+  exclusive: false # to run multus
 cluster:
-  id: 1
-  name: asdf
+  id: ${cluster_id}
+  name: ${cluster_name}
 kubeProxyReplacement: true
 enableIPv4BIGTCP: true
 endpointRoutes:

--- a/modules/talos-cluster/resources/templates/machine_install.yaml.tmpl
+++ b/modules/talos-cluster/resources/templates/machine_install.yaml.tmpl
@@ -4,3 +4,9 @@ machine:
 %{ for selector in disk_selectors ~}
       ${selector}
 %{ endfor ~}
+    extraKernelArgs:
+%{ for arg in extra_kernel_args ~}
+      - ${arg}
+%{ endfor ~}
+    image: ${disk_image}
+    wipe: ${wipe}

--- a/modules/talos-cluster/resources/templates/machine_kubelet_nodeip_validSubnets.yaml.tmpl
+++ b/modules/talos-cluster/resources/templates/machine_kubelet_nodeip_validSubnets.yaml.tmpl
@@ -2,4 +2,4 @@ machine:
   kubelet:
     nodeIP:
       validSubnets:
-        - ${cluster_subnet}
+        - ${node_subnet}

--- a/modules/talos-cluster/versions.tf
+++ b/modules/talos-cluster/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     talos = {
       source  = "siderolabs/talos"
-      version = "0.7.0-alpha.0"
+      version = "0.7.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/tests/talos_cluster_ha_cp_test.go
+++ b/tests/talos_cluster_ha_cp_test.go
@@ -76,7 +76,13 @@ func createTalosClusterHACPOptions() *terraform.Options {
 				"role":   "controlplane",
 			},
 			"install": map[string]interface{}{
-				"diskSelector": []string{"type: 'ssd'"},
+				"diskSelector":    []string{"type: 'ssd'"},
+				"extraKernelArgs": []string{"apparmor=0"},
+				"extensions":      []string{"iscsi-tools", "util-linux-tools"},
+				"secureboot":      false,
+				"wipe":            false,
+				"architecture":    "amd64",
+				"platform":        "metal",
 			},
 			"interfaces": []map[string]interface{}{
 				{
@@ -103,7 +109,13 @@ func createTalosClusterHACPOptions() *terraform.Options {
 				"role":   "controlplane",
 			},
 			"install": map[string]interface{}{
-				"diskSelector": []string{"type: 'ssd'"},
+				"diskSelector":    []string{"type: 'ssd'"},
+				"extraKernelArgs": []string{"apparmor=0"},
+				"extensions":      []string{"iscsi-tools", "util-linux-tools"},
+				"secureboot":      false,
+				"wipe":            false,
+				"architecture":    "amd64",
+				"platform":        "metal",
 			},
 			"interfaces": []map[string]interface{}{
 				{
@@ -130,7 +142,13 @@ func createTalosClusterHACPOptions() *terraform.Options {
 				"role":   "controlplane",
 			},
 			"install": map[string]interface{}{
-				"diskSelector": []string{"type: 'ssd'"},
+				"diskSelector":    []string{"type: 'ssd'"},
+				"extraKernelArgs": []string{"apparmor=0"},
+				"extensions":      []string{"iscsi-tools", "util-linux-tools"},
+				"secureboot":      false,
+				"wipe":            false,
+				"architecture":    "amd64",
+				"platform":        "metal",
 			},
 			"interfaces": []map[string]interface{}{
 				{

--- a/tests/talos_cluster_helpers.go
+++ b/tests/talos_cluster_helpers.go
@@ -30,7 +30,13 @@ type IPMI struct {
 }
 
 type Install struct {
-	DiskSelector string `mapstructure:"diskSelector"`
+	DiskSelector    string   `mapstructure:"diskSelector"`
+	ExtraKernelArgs string   `mapstructure:"extraKernelArgs"`
+	Extensions      []string `mapstructure:"extensions"`
+	SecureBoot      bool     `mapstructure:"secureboot"`
+	Wipe            bool     `mapstructure:"wipe"`
+	Architecture    string   `mapstructure:"architecture"`
+	Platform        string   `mapstructure:"platform"`
 }
 
 type Cluster struct {

--- a/tests/talos_cluster_single_node_test.go
+++ b/tests/talos_cluster_single_node_test.go
@@ -77,7 +77,13 @@ func createTalosClusterSingleNodeOptions() *terraform.Options {
 				"role":   "controlplane",
 			},
 			"install": map[string]interface{}{
-				"diskSelector": []string{"type: 'ssd'"},
+				"diskSelector":    []string{"type: 'ssd'"},
+				"extraKernelArgs": []string{"apparmor=0"},
+				"extensions":      []string{"iscsi-tools", "util-linux-tools"},
+				"secureboot":      false,
+				"wipe":            false,
+				"architecture":    "amd64",
+				"platform":        "metal",
 			},
 			"interfaces": []map[string]interface{}{
 				{


### PR DESCRIPTION
```sh
--- PASS: TestTalosClusterHACP (204.45s)
    --- PASS: TestTalosClusterHACP/group (0.00s)
        --- PASS: TestTalosClusterHACP/group/validateKubernetesVersionConfig (1.05s)
        --- PASS: TestTalosClusterHACP/group/validateTalosControlPlaneSchedulingConfig (1.42s)
        --- PASS: TestTalosClusterHACP/group/validateTalosNTPServersConfig (1.51s)
        --- PASS: TestTalosClusterHACP/group/validateTalosHostDnsConfig (1.53s)
        --- PASS: TestTalosClusterHACP/group/validateTalosNameserversConfig (1.53s)
        --- PASS: TestTalosClusterHACP/group/validateTalosHostnameConfig (1.57s)
PASS
ok      github.com/ionfury/homelab-terraform-modules/tests      205.021s
```
#minor